### PR TITLE
Add option `-metric-key-prefix`

### DIFF
--- a/delayed-job-count.go
+++ b/delayed-job-count.go
@@ -22,13 +22,13 @@ var graphdef = map[string](mp.Graphs){
 	},
 }
 
-// DelayedJobCountPlugin structure
+// DelayedJobCountPlugin mackerel plugin for delayed_job
 type DelayedJobCountPlugin struct {
 	driverName     string
 	dataSourceName string
 }
 
-// FetchMetrics fetchs the metrics
+// FetchMetrics interface for PluginWithPrefix
 func (dj DelayedJobCountPlugin) FetchMetrics() (map[string]interface{}, error) {
 	db, err := sql.Open(dj.driverName, dj.dataSourceName)
 	if err != nil {
@@ -150,7 +150,7 @@ SELECT count FROM (
 	return queued, processing, failed, err
 }
 
-// GraphDefinition is mackerel graph definition
+// GraphDefinition interface for PluginWithPrefix
 func (dj DelayedJobCountPlugin) GraphDefinition() map[string](mp.Graphs) {
 	return graphdef
 }

--- a/delayed-job-count.go
+++ b/delayed-job-count.go
@@ -9,19 +9,6 @@ import (
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
-var graphdef = map[string](mp.Graphs){
-	"delayed_job": {
-		Label: "Delayed Job Count",
-		Unit:  "integer",
-		Metrics: [](mp.Metrics){
-			{Name: "processed", Label: "Processed Job Count", Diff: true},
-			{Name: "queued", Label: "Queued Job Count", Type: "uint64"},
-			{Name: "processing", Label: "Processing Job Count", Type: "uint64"},
-			{Name: "failed", Label: "Failed Job Count", Type: "uint64"},
-		},
-	},
-}
-
 // DelayedJobCountPlugin mackerel plugin for delayed_job
 type DelayedJobCountPlugin struct {
 	driverName     string
@@ -152,6 +139,20 @@ SELECT count FROM (
 
 // GraphDefinition interface for PluginWithPrefix
 func (dj DelayedJobCountPlugin) GraphDefinition() map[string](mp.Graphs) {
+	// metric value structure
+	var graphdef = map[string](mp.Graphs){
+		"delayed_job": {
+			Label: "Delayed Job Count",
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				{Name: "processed", Label: "Processed Job Count", Diff: true},
+				{Name: "queued", Label: "Queued Job Count", Type: "uint64"},
+				{Name: "processing", Label: "Processing Job Count", Type: "uint64"},
+				{Name: "failed", Label: "Failed Job Count", Type: "uint64"},
+			},
+		},
+	}
+
 	return graphdef
 }
 

--- a/delayed-job-count.go
+++ b/delayed-job-count.go
@@ -9,6 +9,20 @@ import (
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
+func main() {
+	optName := flag.String("name", "mysql", "driverName")
+	optDSN := flag.String("dsn", "", "dataSourceName")
+	flag.Parse()
+
+	var delayedJobCount DelayedJobCountPlugin
+
+	delayedJobCount.driverName = *optName
+	delayedJobCount.dataSourceName = *optDSN
+
+	helper := mp.NewMackerelPlugin(delayedJobCount)
+	helper.Run()
+}
+
 // DelayedJobCountPlugin mackerel plugin for delayed_job
 type DelayedJobCountPlugin struct {
 	driverName     string
@@ -154,18 +168,4 @@ func (dj DelayedJobCountPlugin) GraphDefinition() map[string](mp.Graphs) {
 	}
 
 	return graphdef
-}
-
-func main() {
-	optName := flag.String("name", "mysql", "driverName")
-	optDSN := flag.String("dsn", "", "dataSourceName")
-	flag.Parse()
-
-	var delayedJobCount DelayedJobCountPlugin
-
-	delayedJobCount.driverName = *optName
-	delayedJobCount.dataSourceName = *optDSN
-
-	helper := mp.NewMackerelPlugin(delayedJobCount)
-	helper.Run()
 }

--- a/delayed-job-count.go
+++ b/delayed-job-count.go
@@ -41,12 +41,12 @@ func (p DelayedJobCountPlugin) FetchMetrics() (map[string]interface{}, error) {
 	}
 	defer db.Close()
 
-	totalProcessedCount, err := GetTotalProcessedCount(db)
+	totalProcessedCount, err := getTotalProcessedCount(db)
 	if err != nil {
 		return nil, err
 	}
 
-	queuedCount, processingCount, failedCount, err := GetOtherCounts(db)
+	queuedCount, processingCount, failedCount, err := getOtherCounts(db)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +59,8 @@ func (p DelayedJobCountPlugin) FetchMetrics() (map[string]interface{}, error) {
 	}, nil
 }
 
-// GetTotalProcessedCount is total processed count
-func GetTotalProcessedCount(db *sql.DB) (uint64, error) {
+// getTotalProcessedCount is total processed count
+func getTotalProcessedCount(db *sql.DB) (uint64, error) {
 	rows, err := db.Query("SHOW TABLE STATUS LIKE 'delayed_jobs'")
 	if err != nil {
 		return 0, err
@@ -86,7 +86,7 @@ func GetTotalProcessedCount(db *sql.DB) (uint64, error) {
 		return 0, err
 	}
 
-	autoIncrement, err := strconv.ParseUint(string(values[NthAutoIncrement(columns)]), 10, 64)
+	autoIncrement, err := strconv.ParseUint(string(values[nthAutoIncrement(columns)]), 10, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -94,8 +94,8 @@ func GetTotalProcessedCount(db *sql.DB) (uint64, error) {
 	return autoIncrement - 1, err
 }
 
-// NthAutoIncrement is position in columns
-func NthAutoIncrement(columns []string) int {
+// nthAutoIncrement is position in columns
+func nthAutoIncrement(columns []string) int {
 	for key, value := range columns {
 		if value == "Auto_increment" {
 			return key
@@ -105,8 +105,8 @@ func NthAutoIncrement(columns []string) int {
 	return -1
 }
 
-// GetOtherCounts is some counts except the total processed count
-func GetOtherCounts(db *sql.DB) (queued uint64, processing uint64, failed uint64, error error) {
+// getOtherCounts is some counts except the total processed count
+func getOtherCounts(db *sql.DB) (queued uint64, processing uint64, failed uint64, error error) {
 	const query string = `
 SELECT count FROM (
   -- queued job


### PR DESCRIPTION
## Before

```
$ mackerel-plugin-delayed-job-count -dsn <DSN>
delayed_job.processed   0.000000        1489832025
delayed_job.queued      0       1489832025
delayed_job.processing  0       1489832025
delayed_job.failed      0       1489832025
```

## After

```
$ mackerel-plugin-delayed-job-count -dsn <DSN>
delayed_job.count.processed   0.000000        1489832025
delayed_job.count.queued      0       1489832025
delayed_job.count.processing  0       1489832025
delayed_job.count.failed      0       1489832025
```

```
$ mackerel-plugin-delayed-job-count -dsn <DSN> -metric-key-prefix hoge
hoge.count.processed   0.000000        1489832025
hoge.count.queued      0       1489832025
hoge.count.processing  0       1489832025
hoge.count.failed      0       1489832025
```

## Comment

[v0.0.1](https://github.com/masutaka/mackerel-plugin-delayed-job-count/releases/tag/v0.0.1) と master が乖離してきたので、v1.0.0 を出しておきたい。

しかしもうだいぶ忘れてる。。。
